### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ export default class RouteGoverness extends HeadGoverness {
   guard(action, { next }) {
     // or your very own logic to redirect user
     // see. https://github.com/JiriChara/vue-kindergarten/issues/5 for inspiration
-    return this.isAllowed(action) ? next('/') : next();
+    return this.isAllowed(action) ? next() : next('/');
   }
 }
 ```


### PR DESCRIPTION
Usage of VueRouter's `next()` function in the Route Governess example showed a ternary statement whose results were reversed.