### PR TITLE
Use Array.some() method on route guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ const router = new Router({
 });
 
 router.beforeEach((to, from, next) => {
-  to.matched.forEach((routeRecord) => {
+  to.matched.some((routeRecord) => {
     const perimeter = routeRecord.meta.perimeter;
     const Governess = routeRecord.meta.governess || RouteGoverness;
     const action = routeRecord.meta.perimeterAction || 'route';


### PR DESCRIPTION
In the README, show use of `Array.some()` versus `Array.forEach()` so that the iterator doesn't have the opportunity to locate a more deeply nested route which lacks route-blocking meta.